### PR TITLE
Refactor market parameters panel

### DIFF
--- a/components/InteractiveOptionsChart.tsx
+++ b/components/InteractiveOptionsChart.tsx
@@ -6,10 +6,9 @@ import {
   CardTitle,
 } from './ui/card';
 import { Button } from './ui/button';
-import { TooltipProvider } from './ui/tooltip';
-import { Activity, Zap, HelpCircle, AlertCircle } from 'lucide-react';
+import { Zap, HelpCircle, AlertCircle } from 'lucide-react';
 import { motion, AnimatePresence } from 'motion/react';
-import ParameterSlider from './ParameterSlider';
+import { OptionsParameters } from './OptionsParameters';
 import { GreeksExplainer, OptionsData } from './GreeksExplainer';
 import { StrategyCard } from './StrategyCard';
 import {
@@ -17,7 +16,6 @@ import {
   OptionsStrategy,
   PayoffPoint,
 } from '../lib/strategies';
-import { quickPresets } from '../lib/presets';
 import { validateParameters } from '../lib/optionsUtils';
 
 export { validateParameters } from '../lib/optionsUtils';
@@ -198,95 +196,11 @@ export const InteractiveOptionsChart = () => {
         </div>
       )}
 
-      <TooltipProvider>
-        <Card className="mb-6">
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <Activity className="w-5 h-5" />
-              Market Parameters & Option Pricing Inputs
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="grid md:grid-cols-2 gap-4">
-              <ParameterSlider
-                label="currentPrice"
-                value={optionsData.currentPrice}
-                min={50}
-                max={200}
-                step={1}
-                onChange={(v) => updateOption('currentPrice', v)}
-              />
-              <ParameterSlider
-                label="strikePrice"
-                value={optionsData.strikePrice}
-                min={50}
-                max={200}
-                step={5}
-                onChange={(v) => updateOption('strikePrice', v)}
-              />
-              <ParameterSlider
-                label="premium"
-                value={optionsData.premium}
-                min={0.5}
-                max={30}
-                step={0.25}
-                onChange={(v) => updateOption('premium', v)}
-              />
-              <ParameterSlider
-                label="daysToExpiry"
-                value={optionsData.daysToExpiry}
-                min={1}
-                max={365}
-                step={1}
-                onChange={(v) => updateOption('daysToExpiry', v)}
-              />
-              <ParameterSlider
-                label="impliedVolatility"
-                value={optionsData.impliedVolatility}
-                min={5}
-                max={100}
-                step={1}
-                onChange={(v) => updateOption('impliedVolatility', v)}
-              />
-              <ParameterSlider
-                label="interestRate"
-                value={optionsData.interestRate}
-                min={0}
-                max={10}
-                step={0.1}
-                onChange={(v) => updateOption('interestRate', v)}
-              />
-              <ParameterSlider
-                label="dividendYield"
-                value={optionsData.dividendYield}
-                min={0}
-                max={5}
-                step={0.1}
-                onChange={(v) => updateOption('dividendYield', v)}
-              />
-            </div>
-            <div className="flex flex-wrap gap-2 mt-4">
-              {Object.entries(quickPresets).map(([key, preset]) => {
-                const labels: Record<string, string> = {
-                  ATMOption: 'ATM Option',
-                  OTMCall: 'OTM Call',
-                  OTMPut: 'OTM Put',
-                  HighVol: 'High Volatility',
-                };
-                return (
-                  <Button
-                    key={key}
-                    size="sm"
-                    onClick={() => handlePreset(preset, labels[key])}
-                  >
-                    {labels[key]}
-                  </Button>
-                );
-              })}
-            </div>
-          </CardContent>
-        </Card>
-      </TooltipProvider>
+      <OptionsParameters
+        optionsData={optionsData}
+        onChange={updateOption}
+        onPreset={handlePreset}
+      />
 
       <Card className="mb-6">
         <CardHeader>

--- a/components/OptionsParameters.tsx
+++ b/components/OptionsParameters.tsx
@@ -1,60 +1,35 @@
 import React from 'react';
-import { Card, CardContent, CardHeader, CardTitle } from './ui/card';
-import { Slider } from './ui/slider';
-import { Button } from './ui/button';
 import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from './ui/tooltip';
-import { Activity } from 'lucide-react';
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from './ui/card';
+import { Button } from './ui/button';
+import { TooltipProvider } from './ui/tooltip';
+import { Activity, Target, TrendingUp, TrendingDown, Zap } from 'lucide-react';
+import { ParameterSlider } from './ParameterSlider';
 import type { OptionsData } from './GreeksExplainer';
-import { quickPresets, parameterTooltips } from '../lib/presets';
+import { quickPresets } from '../lib/presets';
 
 interface OptionsParametersProps {
   optionsData: OptionsData;
-  onChange: (data: OptionsData) => void;
-  onPreset: (data: OptionsData) => void;
+  onChange: (key: keyof OptionsData, value: number) => void;
+  onPreset: (data: OptionsData, label: string) => void;
 }
 
-export const OptionsParameters = ({
+export const OptionsParameters: React.FC<OptionsParametersProps> = ({
   optionsData,
   onChange,
   onPreset,
-}: OptionsParametersProps) => {
-  const ParameterSlider = (
-    label: keyof OptionsData,
-    min: number,
-    max: number,
-    step: number,
-  ) => (
-    <div className="mb-4" key={label}>
-      <div className="flex justify-between mb-1">
-        <span className="text-sm capitalize">
-          {label.replace(/([A-Z])/g, ' $1')}
-        </span>
-        <span className="text-sm">{optionsData[label]}</span>
-      </div>
-      <Tooltip>
-        <TooltipTrigger>
-          <Slider
-            aria-label={label}
-            aria-valuetext={`${optionsData[label]}`}
-            min={min}
-            max={max}
-            step={step}
-            value={[optionsData[label]]}
-            onValueChange={(v) => onChange({ ...optionsData, [label]: v[0] })}
-          />
-        </TooltipTrigger>
-        <TooltipContent>
-          <strong>{parameterTooltips[label].title}</strong>
-          <p>{parameterTooltips[label].content}</p>
-        </TooltipContent>
-      </Tooltip>
-    </div>
-  );
+}) => {
+  const presets = [
+    { name: 'ATM Option', icon: Target, values: quickPresets.ATMOption },
+    { name: 'OTM Call', icon: TrendingUp, values: quickPresets.OTMCall },
+    { name: 'OTM Put', icon: TrendingDown, values: quickPresets.OTMPut },
+    { name: 'High Vol', icon: Zap, values: quickPresets.HighVol },
+  ];
 
   return (
     <TooltipProvider>
@@ -64,21 +39,87 @@ export const OptionsParameters = ({
             <Activity className="w-5 h-5" />
             Market Parameters & Option Pricing Inputs
           </CardTitle>
+          <CardDescription>
+            Adjust market assumptions to see how pricing and payoffs change.
+          </CardDescription>
         </CardHeader>
         <CardContent>
-          {ParameterSlider('currentPrice', 50, 200, 1)}
-          {ParameterSlider('strikePrice', 50, 200, 5)}
-          {ParameterSlider('premium', 0.5, 30, 0.25)}
-          {ParameterSlider('daysToExpiry', 1, 365, 1)}
-          {ParameterSlider('impliedVolatility', 5, 100, 1)}
-          {ParameterSlider('interestRate', 0, 10, 0.1)}
-          {ParameterSlider('dividendYield', 0, 5, 0.1)}
-          <div className="flex gap-2 mt-4">
-            {Object.entries(quickPresets).map(([k, v]) => (
-              <Button key={k} onClick={() => onPreset(v)}>
-                {k}
-              </Button>
-            ))}
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+            <ParameterSlider
+              label="currentPrice"
+              optionsData={optionsData}
+              min={50}
+              max={200}
+              step={1}
+              onChange={(v) => onChange('currentPrice', v)}
+            />
+            <ParameterSlider
+              label="strikePrice"
+              optionsData={optionsData}
+              min={50}
+              max={200}
+              step={5}
+              onChange={(v) => onChange('strikePrice', v)}
+            />
+            <ParameterSlider
+              label="premium"
+              optionsData={optionsData}
+              min={0.5}
+              max={30}
+              step={0.25}
+              onChange={(v) => onChange('premium', v)}
+            />
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-4 gap-6 mt-6">
+            <ParameterSlider
+              label="daysToExpiry"
+              optionsData={optionsData}
+              min={1}
+              max={365}
+              step={1}
+              onChange={(v) => onChange('daysToExpiry', v)}
+            />
+            <ParameterSlider
+              label="impliedVolatility"
+              optionsData={optionsData}
+              min={5}
+              max={100}
+              step={1}
+              onChange={(v) => onChange('impliedVolatility', v)}
+            />
+            <ParameterSlider
+              label="interestRate"
+              optionsData={optionsData}
+              min={0}
+              max={10}
+              step={0.1}
+              onChange={(v) => onChange('interestRate', v)}
+            />
+            <ParameterSlider
+              label="dividendYield"
+              optionsData={optionsData}
+              min={0}
+              max={5}
+              step={0.1}
+              onChange={(v) => onChange('dividendYield', v)}
+            />
+          </div>
+          <div className="mt-6 pt-6 border-t">
+            <h4 className="mb-3 font-medium">Quick Presets</h4>
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+              {presets.map((p) => (
+                <Button
+                  key={p.name}
+                  variant="outline"
+                  size="sm"
+                  onClick={() => onPreset(p.values, p.name)}
+                  className="text-xs"
+                >
+                  <p.icon className="w-3 h-3 mr-1" />
+                  {p.name}
+                </Button>
+              ))}
+            </div>
           </div>
         </CardContent>
       </Card>
@@ -86,3 +127,4 @@ export const OptionsParameters = ({
   );
 };
 
+export default OptionsParameters;

--- a/components/ParameterSlider.tsx
+++ b/components/ParameterSlider.tsx
@@ -1,6 +1,12 @@
 import React from 'react';
 import { Slider } from './ui/slider';
-import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip';
+import { Badge } from './ui/badge';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from './ui/tooltip';
+import { HelpCircle } from 'lucide-react';
 import type { OptionsData } from './GreeksExplainer';
 import { parameterTooltips } from '../lib/presets';
 
@@ -25,7 +31,7 @@ const displayConfig: Record<
   },
   daysToExpiry: {
     label: 'Days to Expiry',
-    format: (v) => `${v} days`,
+    format: (v) => `${v}d`,
     aria: (v) => `${v} days to expiry`,
   },
   impliedVolatility: {
@@ -45,49 +51,79 @@ const displayConfig: Record<
   },
 };
 
+const parameterCalculations: Record<keyof OptionsData, (data: OptionsData) => string> = {
+  currentPrice: (d) => `Diff to strike: $${(d.currentPrice - d.strikePrice).toFixed(2)}`,
+  strikePrice: (d) => `Break-even: $${(d.strikePrice + d.premium).toFixed(2)}`,
+  premium: (d) => `Break-even: $${(d.strikePrice + d.premium).toFixed(2)}`,
+  daysToExpiry: (d) => `${(d.daysToExpiry / 365).toFixed(2)} yrs`,
+  impliedVolatility: (d) => `σ ${d.impliedVolatility}%`,
+  interestRate: (d) => `${d.interestRate}% annual`,
+  dividendYield: (d) => `${d.dividendYield}% annual`,
+};
+
 interface ParameterSliderProps {
   label: keyof OptionsData;
-  value: number;
+  optionsData: OptionsData;
   min: number;
   max: number;
   step: number;
   onChange: (value: number) => void;
 }
 
-const ParameterSlider: React.FC<ParameterSliderProps> = ({
+export const ParameterSlider: React.FC<ParameterSliderProps> = ({
   label,
-  value,
+  optionsData,
   min,
   max,
   step,
   onChange,
-}) => (
-  <div className="mb-4">
-    <div className="flex justify-between mb-1">
-      <span className="text-sm">{displayConfig[label].label}</span>
-      <span className="text-sm">{displayConfig[label].format(value)}</span>
+}) => {
+  const value = optionsData[label];
+  return (
+    <div className="space-y-3">
+      <label className="flex items-center justify-between">
+        <span className="flex items-center gap-1">
+          {displayConfig[label].label}
+          <Tooltip>
+            <TooltipTrigger>
+              <HelpCircle className="w-4 h-4 text-muted-foreground hover:text-foreground cursor-help" />
+            </TooltipTrigger>
+            <TooltipContent className="max-w-96 p-4">
+              <div className="space-y-2">
+                <p className="font-semibold text-base">
+                  {parameterTooltips[label].title}
+                </p>
+                <p className="text-sm">{parameterTooltips[label].content}</p>
+              </div>
+            </TooltipContent>
+          </Tooltip>
+        </span>
+        <Badge variant="outline" className="text-sm font-mono">
+          {displayConfig[label].format(value)}
+        </Badge>
+      </label>
+      <Slider
+        value={value}
+        onValueChange={onChange}
+        min={min}
+        max={max}
+        step={step}
+        className="w-full"
+        aria-label={displayConfig[label].label}
+        aria-valuemin={min}
+        aria-valuemax={max}
+        aria-valuenow={value}
+        aria-valuetext={displayConfig[label].aria(value)}
+      />
+      <div className="flex justify-between text-xs text-muted-foreground">
+        <span>{displayConfig[label].format(min)}</span>
+        <span>{displayConfig[label].format(max)}</span>
+      </div>
+      <div className="text-xs text-muted-foreground">
+        {parameterCalculations[label](optionsData)}
+      </div>
     </div>
-    <Tooltip>
-      <TooltipTrigger>
-        <Slider
-          aria-label={displayConfig[label].label}
-          aria-valuemin={min}
-          aria-valuemax={max}
-          aria-valuenow={value}
-          aria-valuetext={displayConfig[label].aria(value)}
-          min={min}
-          max={max}
-          step={step}
-          value={value}
-          onValueChange={(v) => onChange(Number(v))}
-        />
-      </TooltipTrigger>
-      <TooltipContent>
-        <strong>{parameterTooltips[label].title}</strong>
-        <p>{parameterTooltips[label].content}</p>
-      </TooltipContent>
-    </Tooltip>
-  </div>
-);
+  );
+};
 
 export default ParameterSlider;


### PR DESCRIPTION
## Summary
- Replaced inline sliders with dedicated `OptionsParameters` component
- Enhanced `ParameterSlider` with tooltips, value badges, and min/max helpers
- Integrated parameter panel into main chart and preserved preset handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b32b7e1520833189846def076618fd